### PR TITLE
Fix Git executable search logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # rspec failure tracking
 .rspec_status
+.same_boat.journal

--- a/lib/same_boat/crew.rb
+++ b/lib/same_boat/crew.rb
@@ -28,7 +28,7 @@ module SameBoat
 
     class << self
       def git?
-        Pathname.new(`which git`.chomp).exist?
+        Pathname.new(`which git`.chomp).executable?
       end
     end
   end

--- a/lib/same_boat/crew.rb
+++ b/lib/same_boat/crew.rb
@@ -28,7 +28,7 @@ module SameBoat
 
     class << self
       def git?
-        @_git ||= !!`which git`
+        Pathname.new(`which git`.chomp).exist?
       end
     end
   end

--- a/lib/same_boat/crews.rb
+++ b/lib/same_boat/crews.rb
@@ -1,6 +1,6 @@
 module SameBoat
   class Crews
-    def initialize(crews, journal_path:)
+    def initialize(crews, journal_path: SameBoat::DEFAULT_JOURNAL)
       @crews, @journal_path = crews, journal_path
     end
 

--- a/same_boat.gemspec
+++ b/same_boat.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "fakefs"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/same_boat/crews_spec.rb
+++ b/spec/same_boat/crews_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 RSpec.describe SameBoat::Crews do
   describe '#row' do
-    before { FakeFS.activate! }
     let(:raw_crews) { %w(lib/same_boat.rb lib/same_boat/version.rb).map { |path| SameBoat::Crew.new(path) } }
 
     context 'by same crews' do
@@ -23,15 +22,10 @@ RSpec.describe SameBoat::Crews do
 
       it { @crews.row.should be false }
     end
-
-    after { FakeFS.deactivate! }
   end
 
   describe '#journal' do
-    before { FakeFS.activate! }
     let(:raw_crews) { %w(lib/same_boat.rb lib/same_boat/version.rb).map { |path| SameBoat::Crew.new(path) } }
     it { described_class.new(raw_crews).journal.should be_truthy }
-
-    after { FakeFS.deactivate! }
   end
 end

--- a/spec/same_boat_spec.rb
+++ b/spec/same_boat_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe SameBoat do
   describe '.accept' do
-    subject { described_class.accept(double('crews')) }
+    subject { described_class.accept(double('crews'), journal_path: SameBoat::DEFAULT_JOURNAL) }
     it { should be_a described_class::Crews }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require "bundler/setup"
 require "same_boat"
-require "fakefs/safe"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Fixes that searching git executable logic, and rspec.

If you don't have git executable in your PATH, typical systems are returns "git not found" or similar message. So, `!!which git` should be always true. 